### PR TITLE
change max skills of HDWA

### DIFF
--- a/ah.cfg
+++ b/ah.cfg
@@ -239,7 +239,7 @@ HGOB                 = 5,2,COMB,WEAP,ARMO,BUIL
 MAN                  = 4,2,FARM,CARP,HORS,RIDI,SHIP
 LEAD                 = 5,5
 LIZA                 = 5,2,HUNT,RANC,LUMB,HERB
-HDWA                 = 5,2,COMB,MINI,WEAP,ARMO
+HDWA                 = 5,2,MINI,WEAP,ARMO,QUAR,BUIL
 ORC                  = 5,2,COMB,LUMB,MTRA
 UDWA                 = 5,2,COMB,XBOW,MINI,QUAR,ARMO
 


### PR DESCRIPTION
According to the game data (http://atlantis-pbem.com/data) a hill dwarf can learn MINI,WEAP,ARMO,QUAR,BUIL up to level 5.  Change the configuration accordingly.  Here an excerpt from http://atlantis-pbem.com/data :

hill dwarf [HDWA], weight 10, walking capacity 5, moves 2 hexes per
  month. This race may study armorer [ARMO], weaponsmith [WEAP],
  quarrying [QUAR], mining [MINI] and building [BUIL] to level 5 and
  all other skills to level 2