### PR TITLE
skills according to atlantis-pbem.com/data

### DIFF
--- a/ah.cfg
+++ b/ah.cfg
@@ -233,15 +233,16 @@ UNITS_HEX            = LIST_COL_UNIT_DEFAULT
 
 [MAX_SKILL_LEVELS]
 
-GBLN                 = 5,2,MTRA,xbow
-GNOL                 = 5,2,QUAR,COMB,HUNT
-HGOB                 = 5,2,COMB,WEAP,ARMO,BUIL
-MAN                  = 4,2,FARM,CARP,HORS,RIDI,SHIP
-LEAD                 = 5,5
-LIZA                 = 5,2,HUNT,RANC,LUMB,HERB
+CTAU                 = 5,2,LUMB,HORS,RIDI,LBOW,RANC,HEAL
+GBLN                 = 5,2,XBOW,SHIP,WEAP,ENTE
+GNOL                 = 5,2,COMB,HUNT,LUMB,ARMO,CAME
 HDWA                 = 5,2,MINI,WEAP,ARMO,QUAR,BUIL
-ORC                  = 5,2,COMB,LUMB,MTRA
-UDWA                 = 5,2,COMB,XBOW,MINI,QUAR,ARMO
+HELF                 = 5,2,HORS,COMB,LBOW,SHIP,SAIL
+LEAD                 = 5,5
+LIZA                 = 5,2,HUNT,HERB,LBOW,SAIL,HEAL,CARP
+MAN                  = 4,2,FARM,CARP,RIDI,ARMO,COMB,MINI
+ORC                  = 5,2,COMB,LUMB,MINI,BUIL,RANC
+UDWA                 = 5,2,MINI,QUAR,ARMO,WEAP,GCUT
 
 [PANE_MAP]
 


### PR DESCRIPTION
We don't have a HGOB in this atlantis game. So I removed it.
I tried it using it in ah. ah wrote it back in alphabetic order. So
I kept that order.  We don't have a skill MTRA, it seems.  So I
removed it from the skills of the listed races.